### PR TITLE
[FEAT] 메인화면, 일정표 페이지 스켈레톤 UI 추가 및 메소드 시간 측정 AOP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.modelmapper:modelmapper:3.2.0'
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/susussg/pengreenlive/config/aop/TimeTrace.java
+++ b/src/main/java/susussg/pengreenlive/config/aop/TimeTrace.java
@@ -1,0 +1,12 @@
+package susussg.pengreenlive.config.aop;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TimeTrace {
+}

--- a/src/main/java/susussg/pengreenlive/config/aop/TimeTraceAspect.java
+++ b/src/main/java/susussg/pengreenlive/config/aop/TimeTraceAspect.java
@@ -1,0 +1,35 @@
+package susussg.pengreenlive.config.aop;
+
+import lombok.extern.log4j.Log4j2;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Log4j2
+@Component
+@Aspect
+public class TimeTraceAspect {
+
+    // @Pointcut("execution(* com.example.demo.repository..*(..))")
+    @Pointcut("@annotation(susussg.pengreenlive.config.aop.TimeTrace)")
+    private void timeTracePointcut() {
+    }
+
+    @Around("timeTracePointcut()")
+    public Object traceTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+
+        try {
+            stopWatch.start();
+            return joinPoint.proceed(); // 실제 타겟 호출
+        } finally {
+            stopWatch.stop();
+            log.info("{} - Total time = {}s",
+                joinPoint.getSignature().toShortString(),
+                stopWatch.getTotalTimeSeconds());
+        }
+    }
+}

--- a/src/main/java/susussg/pengreenlive/main/Controller/MainController.java
+++ b/src/main/java/susussg/pengreenlive/main/Controller/MainController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import susussg.pengreenlive.config.aop.TimeTrace;
 import susussg.pengreenlive.main.DTO.LiveChanceCarouselDTO;
 import susussg.pengreenlive.main.DTO.MainCarouselDTO;
 import susussg.pengreenlive.main.DTO.ScheduledBroadcastDTO;
@@ -30,7 +31,7 @@ public class MainController {
         log.info("call getMainCarousels");
         return mainService.getMainCarousels();
     }
-
+    @TimeTrace
     @GetMapping("/schedule")
     public ResponseEntity<List<ScheduledBroadcastDTO>> getScheduledBroadcasts(
         @RequestParam(value = "categoryCd", required = false) String categoryCd,


### PR DESCRIPTION
## 📕 제목
- #관련 이슈 번호

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 메서드 수행시간 측정 AOP 구현


## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 메소드의 수행 시간을 측정하고 싶다면 해당 메소드에 @TimeTrace 달아주면 됩니다.
