### PR TITLE
[FEAT] 방송 생성 시 방송 통계 함께 생성되게 추가

### DIFF
--- a/src/main/java/susussg/pengreenlive/broadcast/dto/BroadcastStatistics.java
+++ b/src/main/java/susussg/pengreenlive/broadcast/dto/BroadcastStatistics.java
@@ -1,12 +1,14 @@
 package susussg.pengreenlive.broadcast.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class BroadcastStatistics {
     long broadcastSeq;
     int avgViewerCount;

--- a/src/main/java/susussg/pengreenlive/broadcast/service/LiveRegisterServiceImpl.java
+++ b/src/main/java/susussg/pengreenlive/broadcast/service/LiveRegisterServiceImpl.java
@@ -21,6 +21,8 @@ public class LiveRegisterServiceImpl implements LiveRegisterService {
     @Autowired
     private final LiveRegisterMapper liveRegisterMapper;
 
+    private final BroadcastStatisticsService broadcastStatisticsService;
+
     @Override
     @Transactional
     public String getChannelName(long vendorId) {
@@ -47,6 +49,20 @@ public class LiveRegisterServiceImpl implements LiveRegisterService {
     @Transactional
     public void saveBroadcast(BroadcastDTO broadcastDTO) {
         int result = liveRegisterMapper.insertBroadcast(broadcastDTO);
+        BroadcastStatistics broadcastStatistics = BroadcastStatistics.builder()
+                        .broadcastSeq(broadcastDTO.getBroadcastSeq())
+                                .broadcastDuration(0)
+                                        .avgProductClicks(0)
+                                                .avgViewerCount(0)
+                                                        .avgViewingTime(0)
+                                                                .likesCount(0)
+                                                                        .maxViewerCount(0)
+                                                                                .avgPurchaseAmount(0)
+                                                                                        .totalSalesAmount(0)
+                                                                                                .totalSalesQty(0)
+                                                                                                        .viewsCount(0)
+                                                                                                                .build();
+        broadcastStatisticsService.insertBroadcastStatistics(broadcastStatistics);
         if (result != 1) {
             throw new RuntimeException("broadcast insert failed");
         }


### PR DESCRIPTION
## 📕 제목
- #관련 이슈 번호

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 방송 생성 시 방송 통계 함께 생성되게 추가
- [x] 방송 통계 빌더 패턴 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 방송 통계는 실시간으로 계속 업데이트되는 컬럼이 많기 떄문에 초기값은 0으로 설정했습니다.(조회수와 같은건 계속 +시켜야해서도 있습니다.)
