### PR TITLE
[FEAT] 주문 관련 JPA 설정 및 API 구현

### DIFF
--- a/src/main/java/susussg/pengreenlive/order/controller/OrderController.java
+++ b/src/main/java/susussg/pengreenlive/order/controller/OrderController.java
@@ -22,6 +22,7 @@ public class OrderController {
     public ResponseEntity<?> create(@RequestBody OrderFormDTO orderForm) {
         log.info("OrderController {}", orderForm);
 
+        orderForm.setUserUUID("f23a72e0-1347-11ef-b085-f220affc9a21");
         try {
             Long orderSeq = orderService.persistOrder(orderForm);
             return ResponseEntity.ok().body(orderSeq);

--- a/src/main/java/susussg/pengreenlive/order/domain/Broadcast.java
+++ b/src/main/java/susussg/pengreenlive/order/domain/Broadcast.java
@@ -1,0 +1,63 @@
+package susussg.pengreenlive.order.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity(name = "TB_BROADCAST")
+public class Broadcast {
+    @Id
+    @Column(name = "BROADCAST_SEQ")
+    private long broadcastSeq;
+
+    @Column(name = "CHANNEL_NM")
+    private String channelNm;
+
+    @Column(name = "BROADCAST_TITLE")
+    private String broadcastTitle;
+
+    @Column(name = "BROADCAST_IMAGE")
+    private String broadcastImage;
+
+    @Column(name = "BROADCAST_SUMMARY")
+    private String broadcastSummary;
+
+    @Column(name = "BROADCAST_SCHEDULED_TIME")
+    private LocalDateTime broadcastScheduledTime;
+
+    @Column(name = "BROADCAST_START_TIME")
+    private LocalDateTime broadcastStartTime;
+
+    @Column(name = "BROADCAST_END_TIME")
+    private LocalDateTime broadcastEndTime;
+
+    @Column(name = "LIKES_COUNT")
+    private int likesCount;
+
+    @Column(name = "VIEW_COUNT")
+    private int viewCount;
+
+    @Column(name = "SCRIPT")
+    private String script;
+
+    @Column(name = "BROADCAST_YN")
+    private boolean broadcastYn;
+
+    @Column(name = "BROADCAST_SOURCE_INFO")
+    private String broadcastSourceInfo;
+
+    @Column(name = "CATEGORY_CD")
+    private String categoryCd;
+
+    @Column(name = "CHANNEL_SEQ")
+    private long channelSeq;
+}

--- a/src/main/java/susussg/pengreenlive/order/domain/Channel.java
+++ b/src/main/java/susussg/pengreenlive/order/domain/Channel.java
@@ -1,0 +1,35 @@
+package susussg.pengreenlive.order.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity(name = "TB_CHANNEL")
+public class Channel {
+
+    @Id
+    @Column(name="CHANNEL_SEQ")
+    private Long channelSeq;
+
+    @Column(name="VENDOR_SEQ")
+    private Long vendorSeq;
+
+    @Column(name = "CHANNEL_NM")
+    private String channelNm;
+
+    @Column(name = "CHANNEL_URL")
+    private String channelUrl;
+
+    @Column(name = "CHANNEL_IMAGE")
+    private String channelImage;
+
+    @Column(name = "CHANNEL_INFO")
+    private String channelInfo;
+}

--- a/src/main/java/susussg/pengreenlive/order/domain/Order.java
+++ b/src/main/java/susussg/pengreenlive/order/domain/Order.java
@@ -12,20 +12,45 @@ import java.time.LocalDateTime;
 @Entity(name = "TB_ORDER")
 public class Order {
 
-    @Id @GeneratedValue
-    @Column(name="order_seq")
-    long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ORDER_SEQ")
+    private long id;
 
-    String userUUID;
-    long productSeq;
-    int orderQty;
-    String orderPayment;
-    LocalDateTime orderDate;
-    int orderProductPrice;
-    int orderPayedPrice;
-    long broadcastSeq;
-    String deliveryStatus;
-    boolean reivewYn;
-    long vendorSeq;
-    long channelSeq;
+    @Column(name = "USER_UUID")
+    private String userUUID;
+
+    @OneToOne(optional = true)
+    @JoinColumn(name = "PRODUCT_SEQ", referencedColumnName = "PRODUCT_SEQ")
+    private Product product;
+
+    @Column(name = "ORDER_QTY")
+    private int orderQty;
+
+    @Column(name = "ORDER_PAYMENT")
+    private String orderPayment;
+
+    @Column(name = "ORDER_DATE")
+    private LocalDateTime orderDate;
+
+    @Column(name = "ORDER_PRODUCT_PRICE")
+    private int orderProductPrice;
+
+    @Column(name = "ORDER_PAYED_PRICE")
+    private int orderPayedPrice;
+
+    @Column(name = "BROADCAST_SEQ")
+    private long broadcastSeq;
+
+    @Column(name = "DELIVERY_STATUS")
+    private String deliveryStatus;
+
+    @Column(name = "REVIEW_YN")
+    private boolean reviewYn;
+
+    @Column(name = "VENDOR_SEQ")
+    private long vendorSeq;
+
+    @Column(name = "CHANNEL_SEQ")
+    private long channelSeq;
 }

--- a/src/main/java/susussg/pengreenlive/order/domain/Order.java
+++ b/src/main/java/susussg/pengreenlive/order/domain/Order.java
@@ -2,6 +2,7 @@ package susussg.pengreenlive.order.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import susussg.pengreenlive.order.util.UUIDConverter;
 
 import java.time.LocalDateTime;
 
@@ -17,7 +18,8 @@ public class Order {
     @Column(name = "ORDER_SEQ")
     private long id;
 
-    @Column(name = "USER_UUID")
+    @Convert(converter = UUIDConverter.class)
+    @Column(name = "USER_UUID", columnDefinition = "BINARY(16)")
     private String userUUID;
 
     @OneToOne(optional = true)
@@ -39,8 +41,9 @@ public class Order {
     @Column(name = "ORDER_PAYED_PRICE")
     private int orderPayedPrice;
 
-    @Column(name = "BROADCAST_SEQ")
-    private long broadcastSeq;
+    @OneToOne
+    @JoinColumn(name="BROADCAST_SEQ")
+    private Broadcast broadcast;
 
     @Column(name = "DELIVERY_STATUS")
     private String deliveryStatus;
@@ -51,6 +54,7 @@ public class Order {
     @Column(name = "VENDOR_SEQ")
     private long vendorSeq;
 
-    @Column(name = "CHANNEL_SEQ")
-    private long channelSeq;
+    @OneToOne
+    @JoinColumn(name = "CHANNEL_SEQ")
+    private Channel channel;
 }

--- a/src/main/java/susussg/pengreenlive/order/domain/Product.java
+++ b/src/main/java/susussg/pengreenlive/order/domain/Product.java
@@ -12,7 +12,6 @@ import lombok.*;
 public class Product {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "PRODUCT_SEQ")
     private long productSeq;
 

--- a/src/main/java/susussg/pengreenlive/order/domain/Product.java
+++ b/src/main/java/susussg/pengreenlive/order/domain/Product.java
@@ -1,0 +1,39 @@
+package susussg.pengreenlive.order.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "TB_PRODUCT")
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "PRODUCT_SEQ")
+    private long productSeq;
+
+    @Column(name = "PRODUCT_CD")
+    private String productCd;
+
+    @Column(name = "GREEN_PRODUCT_ID")
+    private String greenProductId;
+
+    @Column(name = "PRODUCT_NM")
+    private String productNm;
+
+    @Column(name = "LIST_PRICE")
+    private int listPrice;
+
+    @Column(name = "BRAND")
+    private String brand;
+
+    @Column(name = "PRODUCT_IMAGE")
+    private String productImage;
+
+    @Column(name = "CATEGORY_CD")
+    private String categoryCd;
+}

--- a/src/main/java/susussg/pengreenlive/order/domain/ProductStock.java
+++ b/src/main/java/susussg/pengreenlive/order/domain/ProductStock.java
@@ -1,0 +1,24 @@
+package susussg.pengreenlive.order.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "TB_PRODUCT_STOCK")
+public class ProductStock {
+
+    @Id
+    @OneToOne
+    @JoinColumn(name = "PRODUCT_SEQ")
+    private Product product;
+
+    @Column(name="PRODUCT_STOCK")
+    private int productStock;
+}

--- a/src/main/java/susussg/pengreenlive/order/dto/BroadcastDTO.java
+++ b/src/main/java/susussg/pengreenlive/order/dto/BroadcastDTO.java
@@ -1,0 +1,18 @@
+package susussg.pengreenlive.order.dto;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BroadcastDTO {
+    private long broadcastSeq;
+    private long channelSeq;
+}

--- a/src/main/java/susussg/pengreenlive/order/dto/OrderFormDTO.java
+++ b/src/main/java/susussg/pengreenlive/order/dto/OrderFormDTO.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Data
 @Getter
 @Setter

--- a/src/main/java/susussg/pengreenlive/order/dto/ProductStockDTO.java
+++ b/src/main/java/susussg/pengreenlive/order/dto/ProductStockDTO.java
@@ -1,0 +1,14 @@
+package susussg.pengreenlive.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import susussg.pengreenlive.order.domain.Product;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductStockDTO {
+    private Product product;
+    private int productStock;
+}

--- a/src/main/java/susussg/pengreenlive/order/repository/OrderRepository.java
+++ b/src/main/java/susussg/pengreenlive/order/repository/OrderRepository.java
@@ -2,15 +2,30 @@ package susussg.pengreenlive.order.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
+import susussg.pengreenlive.order.domain.Broadcast;
+import susussg.pengreenlive.order.domain.Channel;
 import susussg.pengreenlive.order.domain.Order;
 
+@Slf4j
 @RequiredArgsConstructor
 @Repository
 public class OrderRepository {
     final private EntityManager em;
 
     public void save(Order order) {
+        Broadcast broadcast = em.find(Broadcast.class, order.getBroadcast().getBroadcastSeq());
+        order.setBroadcast(broadcast);
+        Channel channel = em.find(Channel.class, broadcast.getChannelSeq());
+        log.info("channel = {}", channel);
+        order.setChannel(channel);
+        order.setVendorSeq(channel.getVendorSeq());
+        log.info("order = {}", order);
+
         em.persist(order);
     }
+
+
+
 }

--- a/src/main/java/susussg/pengreenlive/order/repository/ProductRepository.java
+++ b/src/main/java/susussg/pengreenlive/order/repository/ProductRepository.java
@@ -1,0 +1,19 @@
+package susussg.pengreenlive.order.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import susussg.pengreenlive.order.domain.Order;
+import susussg.pengreenlive.order.domain.Product;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductRepository {
+
+    final private EntityManager em;
+
+    public void update(Product product)
+    {
+        em.persist(product);
+    }
+}

--- a/src/main/java/susussg/pengreenlive/order/repository/ProductStockRepository.java
+++ b/src/main/java/susussg/pengreenlive/order/repository/ProductStockRepository.java
@@ -1,0 +1,24 @@
+package susussg.pengreenlive.order.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import susussg.pengreenlive.order.domain.Product;
+import susussg.pengreenlive.order.domain.ProductStock;
+import susussg.pengreenlive.order.dto.ProductStockDTO;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductStockRepository {
+
+    final private EntityManager em;
+
+    public void update(Product product)
+    {
+        em.persist(product);
+    }
+
+//    public ProductStockDTO selectByProductSeq(ProductStock productStock) {
+//        return em.find(ProductStock.class, productStock.getProduct().getProductSeq());
+//    }
+}

--- a/src/main/java/susussg/pengreenlive/order/service/OrderService.java
+++ b/src/main/java/susussg/pengreenlive/order/service/OrderService.java
@@ -6,23 +6,39 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import susussg.pengreenlive.order.domain.Order;
+import susussg.pengreenlive.order.domain.ProductStock;
 import susussg.pengreenlive.order.dto.OrderFormDTO;
 import susussg.pengreenlive.order.repository.OrderRepository;
+import susussg.pengreenlive.order.repository.ProductStockRepository;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class OrderService {
     private final OrderRepository orderRepository;
+    private final ProductStockRepository productStockRepository;
     private final ModelMapper modelMapper;
 
     @Transactional
     public Long persistOrder(OrderFormDTO orderForm) {
 
+//        ProductStock productStock = productStockRepository.findByProduct_ProductSeq(orderForm.getProductSeq())
+//                .orElseThrow(() -> new RuntimeException("Product stock not found"));
+//
+//        if (productStock.getProductStock() < orderForm.getOrderQty()) {
+//            throw new RuntimeException("Not enough stock available");
+//        }
+//
+//        productStock.setProductStock(productStock.getProductStock() - orderForm.getOrderQty());
+//        productStockRepository.save(productStock);
+
         Order order = modelMapper.map(orderForm, Order.class);
+        order.setReviewYn(false);
+        order.setDeliveryStatus("결제완료");
         log.info("OrderService {}", order);
 
         orderRepository.save(order);
+
         return order.getId();
     }
 }

--- a/src/main/java/susussg/pengreenlive/order/util/UUIDConverter.java
+++ b/src/main/java/susussg/pengreenlive/order/util/UUIDConverter.java
@@ -1,0 +1,35 @@
+package susussg.pengreenlive.order.util;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+@Converter(autoApply = false)
+public class UUIDConverter implements AttributeConverter<String, byte[]> {
+
+    @Override
+    public byte[] convertToDatabaseColumn(String uuid) {
+        if (uuid == null) {
+            return null;
+        }
+        UUID u = UUID.fromString(uuid);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[16]);
+        byteBuffer.putLong(u.getMostSignificantBits());
+        byteBuffer.putLong(u.getLeastSignificantBits());
+        return byteBuffer.array();
+    }
+
+    @Override
+    public String convertToEntityAttribute(byte[] dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        ByteBuffer byteBuffer = ByteBuffer.wrap(dbData);
+        long high = byteBuffer.getLong();
+        long low = byteBuffer.getLong();
+        UUID uuid = new UUID(high, low);
+        return uuid.toString();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,13 +3,21 @@ spring.profiles.include=secret
 
 server.port=8090
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.sql.init.encoding=UTF-8
 
 logging.level.org.springframework=info
 logging.level.com.ssg=debug
 
-spring.jpa.hibernate.ddl-auto=update
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.enabled=true
+server.servlet.encoding.force=true
+
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.hibernate.naming.physical-strategy = org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
 
 # mybatis setting
 mybatis.mapper-locations=classpath*:mappers/*Mapper.xml 

--- a/src/test/java/susussg/pengreenlive/order/service/OrderServiceTest.java
+++ b/src/test/java/susussg/pengreenlive/order/service/OrderServiceTest.java
@@ -1,0 +1,47 @@
+package susussg.pengreenlive.order.service;
+
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import susussg.pengreenlive.order.dto.OrderFormDTO;
+import susussg.pengreenlive.util.DTO.BanwordValidationResultDTO;
+import susussg.pengreenlive.util.Service.BanwordService;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Log4j2
+public class OrderServiceTest {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Test
+    public void testOrderInsert() {
+        OrderFormDTO orderForm = OrderFormDTO.builder()
+                .userUUID("f23a72e0-1347-11ef-b085-f220affc9a21")
+                .productSeq(3)
+                .orderQty(1)
+                .orderPayment("카드")
+                .orderDate(LocalDateTime.parse("2024-05-20T10:04:50"))
+                .orderProductPrice(7000)
+                .orderPayedPrice(7000)
+                .broadcastSeq(2)
+                .deliveryStatus("결제완료")
+                .reviewYn(false)
+                .vendorSeq(0)
+                .channelSeq(0).build();
+
+        log.info("order form {}", orderForm);
+
+        long orderId = orderService.persistOrder(orderForm);
+        log.info("order Id = {}", orderId);
+    }
+}


### PR DESCRIPTION
## 📕 제목
- 주문 관련 JPA 설정 및 API 구현

## 📗 작업 내용
- [x] 주문 및 재고 엔티티 설정
- [x] 주문 API 구매자 UUID 추가
- [x] DB 인코딩 및 JPA 관련 설정 추가

## 📘 PR 특이 사항
- 슬랙 확인하시고 DB 설정 추가해주세요~
